### PR TITLE
V2026.05.0rc1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dask-image" %}
-{% set version = "2025.11.0" %}
-{% set sha256 = "45cf1a9c3a8a1c143c75d43f1494e4fe0827564d3ec6efb93618fb04603ba0b3" %}
+{% set version = "2026.05.0rc1" %}
+{% set sha256 = "sha256:4834ece8d7133f8cd7d4e672f7f5a598c9057e687b20f14f3121360e3e1690b4" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,8 @@ requirements:
   run:
     - python >=3.9
     - dask-core >=2024.4.1
-    - dask >=2024.4.1
     - numpy >=1.18
     - scipy >=1.7.0
-    - pandas >=2.0.0
     - pims >=0.4.1
     - tifffile >=2018.10.18
 
@@ -38,10 +36,12 @@ test:
 
   imports:
     - dask_image
-
+    - dask.array
   requires:
     - pip
     - pytest >=3.0.5
+    - pandas >=2.0.0
+    - dask >=2024.4.1
 
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,7 @@
 {% set version = "2026.5.0rc1" %}
 {% set sha256 = "sha256:4834ece8d7133f8cd7d4e672f7f5a598c9057e687b20f14f3121360e3e1690b4" %}
 
+
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "dask-image" %}
 {% set version = "2026.5.0rc1" %}
-{% set sha256 = "sha256:05458ebb6674cd7cfdf867a0ef02ce053ea7168f577b3c45e57bbb0073273189" %}
+{% set sha256 = "05458ebb6674cd7cfdf867a0ef02ce053ea7168f577b3c45e57bbb0073273189" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "dask-image" %}
 {% set version = "2026.5.0rc1" %}
-{% set sha256 = "sha256:4834ece8d7133f8cd7d4e672f7f5a598c9057e687b20f14f3121360e3e1690b4" %}
-
+{% set sha256 = "sha256:05458ebb6674cd7cfdf867a0ef02ce053ea7168f577b3c45e57bbb0073273189" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - numpy >=1.18
     - scipy >=1.7.0
     - pims >=0.4.1
-    - tifffile >=2018.10.18
+    - tifffile >=2020.10.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dask-image" %}
-{% set version = "2026.05.0rc1" %}
+{% set version = "2026.5.0rc1" %}
 {% set sha256 = "sha256:4834ece8d7133f8cd7d4e672f7f5a598c9057e687b20f14f3121360e3e1690b4" %}
 
 package:


### PR DESCRIPTION
I'm following the instructions here: https://conda-forge.org/docs/maintainer/knowledge_base/?utm_source=chatgpt.com#creating-a-pre-release-build. Summary:

- Publish dask-image release candidate to PyPI
- Open a feedstock PR for that RC.
- Target an rc branch / dask-image_rc label, not the normal main channel.
- In that PR, make the dependency changes
- After the RC is validated, publish the final PyPI release.
- Let the conda-forge bot open the final release PR, then apply the same recipe changes there if needed.

The idea is to build / test the prerelease since the dependencies changed, as `dask[dataframe]` and `pandas` are optional dependencies upstream now. For the conda feedstock repo, I included them in the test dependencies.