### PR TITLE
Update tifffile minimum required version for dask-image 2026.5.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -4,3 +4,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.10'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ requirements:
     - scipy >=1.7.0
     - pims >=0.4.1
     - tifffile >=2020.10.1
+  run_constrained:
+    - pandas >=2.0.0
+    - dask >=2024.4.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - numpy >=1.18
     - scipy >=1.7.0
     - pims >=0.4.1
-    - tifffile >=2018.10.18
+    - tifffile >=2020.10.1
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,11 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.9
+    - python {{ python_min }}.*
     - setuptools >=64
     - setuptools_scm >=8
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - dask-core >=2024.4.1
     - numpy >=1.18
     - scipy >=1.7.0
@@ -39,6 +39,7 @@ test:
     - dask.array
   requires:
     - pip
+    - python {{ python_min }}.*
     - pytest >=3.0.5
     - pandas >=2.0.0
     - dask >=2024.4.1


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

---

dask-image [2026.5.0](https://github.com/dask/dask-image/releases/tag/v2026.5.0) bumped the minimum required version of tifffile to 2020.10.1 ([diff](https://github.com/dask/dask-image/compare/v2025.11.0...v2026.5.0)). The recent recipe update did not bump the minimum required version (#36, #37). The bot is already configured to use grayskull to auto-update the requirements, so I'm not sure why it failed in this case:

https://github.com/conda-forge/dask-image-feedstock/blob/916da05ab3482b5c22791f4cecb4afda9b4ca3de/conda-forge.yml#L1-L2

While updating the recipe, I made a few other improvements:

* I used [`run_constrained`](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#run-constrained) to formally enforce the minimum required versions of the optional dependencies dask and pandas
* I implemented CFEP-25. The bot PR to implement this had been closed (https://github.com/conda-forge/dask-image-feedstock/pull/33)